### PR TITLE
Resolve FP CPE-Link from netty

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4868,4 +4868,11 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-to\-slf4j@.*$</packageUrl>
         <cpe>cpe:/a:apache:log4j</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per #3889
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-classes@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
+    </suppress>	
 </suppressions>


### PR DESCRIPTION
Fixes #3889.

netty-tcnative-classes:2.0.46.Final is included in io.netty:netty-all:4.1.71.Final

https://nvd.nist.gov/vuln/detail/CVE-2021-43797 impacts netty-all versions prior to 4.1.71.

+--- io.netty:netty-all:4.1.71.Final
|    +--- io.netty:netty-tcnative-classes:2.0.46.Final